### PR TITLE
Allows webview to "directly" call vscode APIs

### DIFF
--- a/chromium-messenger.ts
+++ b/chromium-messenger.ts
@@ -1,0 +1,36 @@
+import * as vscode from "vscode"
+import {WebviewApi} from "vscode-webview"
+import {BaseMessenger} from "./ipc"
+
+type ConnectionFromChromium = WebviewApi<unknown>
+
+export class ChromiumMessenger<S> implements BaseMessenger<S> {
+    public type = "chromium"
+    private connection: ConnectionFromChromium
+    private listening = false
+    constructor(connection: ConnectionFromChromium) {
+        this.connection = connection
+    }
+    listen(fn: (message: S) => void) {
+        if (this.listening) {
+            return
+        }
+        const handler = (event: MessageEvent) => {
+            if (event.origin !== location.origin) {return;}
+            fn(event.data);
+        };
+        window.addEventListener('message', handler);
+        this.listening = true
+        return () => {window.removeEventListener('message', handler); this.listening = false};
+    }
+    post(message: S | {type: "request"} | {type: "command"; data: {command: string; args: any[]}}) {
+        this.connection.postMessage(JSON.parse(JSON.stringify(message)))
+    }
+    requestData() {
+        this.post({type: "request"})
+    }
+    requestCommand(command: string, args: any[]) {
+        console.log('requesting command', command, args)
+        this.post({type: "command", data: {command, args}})
+    }
+}

--- a/extension.ts
+++ b/extension.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode"
 import fs from "fs"
 import path from "path"
-import {Store, getStore} from "./src/state"
+import {Store, getNodeStore} from "./src/state"
 import setupStoreSubscriptions from "./src/node/setupStoreSubscriptions"
+
+const [, connectWebviewToStore] = getNodeStore()
 
 class ViewProvider implements vscode.WebviewViewProvider {
     public readonly viewId: string
@@ -49,7 +51,7 @@ class ViewProvider implements vscode.WebviewViewProvider {
         }
         this.webview = webviewView.webview
         if (!this.store) {
-            this.store = getStore(this.webview)
+            this.store = connectWebviewToStore(this.webview)
 
             import(vscode.Uri.joinPath(
                 this.extensionContext.extensionUri,

--- a/ipc.ts
+++ b/ipc.ts
@@ -2,6 +2,9 @@ import type {StateCreator, StoreApi} from "zustand/vanilla"
 import {createStore} from "zustand/vanilla"
 import * as vscode from "vscode"
 import {WebviewApi} from "vscode-webview"
+import pick from "lodash.pick"
+import {ChromiumMessenger} from "./chromium-messenger"
+import type {NodeMessenger} from "./node-messenger"
 
 // TODO: sending partial state updates???
 
@@ -20,27 +23,38 @@ const ipc: IpcImpl = (storeInitializer, newConnectionFromNode?: vscode.Webview) 
         // if node, we don't instantiate messenger with any webviews (they get registered later)
         // we just want to instantate (and cache) the store]
         if (typeof window === "undefined") {
-            let nodeMessenger: NodeMessenger<ReturnType<typeof get>>
-            if (!messenger) {
-                console.log('new messenger node')
-                nodeMessenger = messenger = new NodeMessenger()
-            } else {
-                console.log('re-use messenger node')
-                nodeMessenger = messenger as NodeMessenger<ReturnType<typeof get>>
-            }
-            if (newConnectionFromNode) {
-                nodeMessenger.addConnection(newConnectionFromNode)
-            }
-            console.log('node messenger state', nodeMessenger.connections.length)
-            nodeMessenger.listen(state => {
-                if (!("type" in state)) {
-                    // respond to chromium request for latest data
-                    console.log(`received by node process`, state);
-                    set(state)
-                    console.log(`new state on node process`, get());
+            (async function () {
+                // running in Node environment
+                let nodeMessenger: NodeMessenger<ReturnType<typeof get>>
+                if (!messenger) {
+                    const {NodeMessenger} = await import("./node-messenger.ts");
+                    nodeMessenger = messenger = new NodeMessenger()
+                } else {
+                    console.log('re-use messenger node')
+                    nodeMessenger = messenger as NodeMessenger<ReturnType<typeof get>>
                 }
-                nodeMessenger.post(get())
-            })
+                // there can be a 1:many messaging relationship between node processes and webviews / chromium processes
+                if (newConnectionFromNode) {
+                    nodeMessenger.addConnection(newConnectionFromNode)
+                }
+                console.log('node messenger state', nodeMessenger.connections.length)
+                nodeMessenger.listen(state => {
+                    console.log("node process", state)
+                    if (!("type" in state)) {
+                        // unless it's a specific request for data, treat incoming messages as updates to the node state
+                        console.log(`received by node process`, state);
+                        set(pick(state, Object.keys(get())))
+                        console.log(`new state on node process`, get());
+                    } else if (state.type === "command") {
+                        const {command, args} = state.data
+                        nodeMessenger.runCommand(command, args)
+                        console.log(`command ${command} run on node process`)
+                        return
+                    }
+                    // on all updates to the node state, broadcast to all webviews
+                    nodeMessenger.post(get())
+                })
+            })()
         } else {
             // running in chromium environment
             let chromiumMessenger: ChromiumMessenger<ReturnType<typeof get>>
@@ -78,59 +92,21 @@ const ipc: IpcImpl = (storeInitializer, newConnectionFromNode?: vscode.Webview) 
 type ConnectionFromChromium = WebviewApi<unknown>
 type ConnectionFromNode = vscode.Webview
 
-abstract class BaseMessenger<S> {
+export abstract class BaseMessenger<S> {
     public abstract type: string
     public listen(fn: (message: any) => void) { }
     public post(message: any) { }
 }
 
-class NodeMessenger<S> implements BaseMessenger<S> {
-    public type = "node"
-    public connections: ConnectionFromNode[] = []
-    private disposeListeners?: () => void
-    listen(fn: (message: S | {type: "request"}) => void) {
-        if (this.disposeListeners) {
-            this.disposeListeners()
+export function useVscode() {
+    if (typeof window === "undefined") {
+        throw new Error("Cannot use command in node environment")
+    }
+    return function (command: string, args: any[]) {
+        if (!messenger) {
+            throw new Error("Cannot use command before store is created")
         }
-        const disposables = this.connections.map(connection => connection.onDidReceiveMessage(fn))
-        return this.disposeListeners = () => {
-            disposables.forEach(disposable => disposable.dispose())
-        };
-    }
-    post(message: S) {
-        this.connections.forEach(connection => {
-            connection.postMessage(JSON.parse(JSON.stringify(message)) as S)
-        })
-    }
-    addConnection(connection: ConnectionFromNode) {
-        this.connections.push(connection)
-    }
-}
-
-class ChromiumMessenger<S> implements BaseMessenger<S> {
-    public type = "chromium"
-    private connection: ConnectionFromChromium
-    private listening = false
-    constructor(connection: ConnectionFromChromium) {
-        this.connection = connection
-    }
-    listen(fn: (message: S) => void) {
-        if (this.listening) {
-            return
-        }
-        const handler = (event: MessageEvent) => {
-            if (event.origin !== location.origin) {return;}
-            fn(event.data);
-        };
-        window.addEventListener('message', handler);
-        this.listening = true
-        return () => {window.removeEventListener('message', handler); this.listening = false};
-    }
-    post(message: S | {type: "request"}) {
-        this.connection.postMessage(JSON.parse(JSON.stringify(message)))
-    }
-    requestData() {
-        this.post({type: "request"})
+        (messenger as ChromiumMessenger<unknown>).requestCommand(command, args)
     }
 }
 

--- a/node-messenger.ts
+++ b/node-messenger.ts
@@ -1,0 +1,41 @@
+import * as vscode from "vscode"
+import {BaseMessenger} from "./ipc"
+
+type ConnectionFromNode = vscode.Webview
+
+export class NodeMessenger<S> implements BaseMessenger<S> {
+    public type = "node"
+    public connections: ConnectionFromNode[] = []
+    public api: typeof vscode = vscode
+    private disposeListeners?: () => void
+
+    listen(fn: (message: S | {type: "request"} | {type: "command"; data: {command: string; args: any[]}}) => void) {
+        if (this.disposeListeners) {
+            this.disposeListeners()
+        }
+        const disposables = this.connections.map(connection => connection.onDidReceiveMessage(fn))
+        return this.disposeListeners = () => {
+            disposables.forEach(disposable => disposable.dispose())
+        };
+    }
+    post(message: S) {
+        this.connections.forEach(connection => {
+            connection.postMessage(JSON.parse(JSON.stringify(message)) as S)
+        })
+    }
+    addConnection(connection: ConnectionFromNode) {
+        this.connections.push(connection)
+    }
+    runCommand(command: string, args: any[]) {
+        // command is a "." delimited string of the command to run
+        // args is an array of arguments to pass to the command
+        // e.g. ["editor.action.formatDocument", []]
+        const indices = command.split(".") as (keyof typeof vscode)[]
+        try {
+            const api = indices.reduce((api: any, index: any) => api[index], this.api)
+            api(...args)
+        } catch (e) {
+            console.error(e)
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
+        "lodash.pick": "^4.4.0",
         "magicbell": "^1.7.1",
         "node-fetch": "^3.3.2",
         "react": "^18.2.0",
@@ -24,6 +25,7 @@
         "@rollup/plugin-replace": "^5.0.2",
         "@rollup/plugin-typescript": "^11.1.2",
         "@sveltejs/vite-plugin-svelte": "^2.4.3",
+        "@types/lodash.pick": "^4.4.7",
         "@types/node": "^20.4.5",
         "@types/react": "^18.2.18",
         "@types/vscode": "^1.74.0",
@@ -1157,6 +1159,21 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.197",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.pick": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.pick/-/lodash.pick-4.4.7.tgz",
+      "integrity": "sha512-HgdyKz7/1+oeoVzbpu1XiX/Bti9AUksHtOILH38T07aKvqoirzcdOsrO2+Yg3L51Hv/8m1MetvHZEUGeABiTiQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.4.5",
@@ -3015,6 +3032,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
+    },
+    "node_modules/lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@rollup/plugin-replace": "^5.0.2",
     "@rollup/plugin-typescript": "^11.1.2",
     "@sveltejs/vite-plugin-svelte": "^2.4.3",
+    "@types/lodash.pick": "^4.4.7",
     "@types/node": "^20.4.5",
     "@types/react": "^18.2.18",
     "@types/vscode": "^1.74.0",
@@ -47,6 +48,7 @@
     "tslib": "^2.6.1"
   },
   "dependencies": {
+    "lodash.pick": "^4.4.0",
     "magicbell": "^1.7.1",
     "node-fetch": "^3.3.2",
     "react": "^18.2.0",

--- a/src/node/setupStoreSubscriptions.ts
+++ b/src/node/setupStoreSubscriptions.ts
@@ -1,10 +1,11 @@
 import NotificationsManager from "../services/NotificationsManager"
-import {getStore} from "../state"
+import {getNodeStore} from "../state"
 
 // See https://vscode-docs.readthedocs.io/en/stable/customization/keybindings/
 
+const [store] = getNodeStore()
+
 export default function () {
-    const store = getStore()
     store.subscribe(state => {
         // handle store subscriptions here
     })

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,7 @@
 import type {StoreApi} from "zustand/vanilla"
 import {Client} from "magicbell"
-import _getStore from "../ipc"
+import _getStore, {useVscode} from "../ipc"
+import * as vscode from "vscode"
 
 type Notification = Awaited<ReturnType<Client["notifications"]["get"]>>
 
@@ -12,8 +13,30 @@ export type State = {
 
 export type Store = StoreApi<State>
 
-export const getStore = _getStore<State>((set) => ({
+const getStore = _getStore<State>((set) => ({
     addNotification: (notification: Notification) => set((state) => ({notifications: [notification, ...state.notifications]})),
     setNotifications: (notifications: Notification[]) => set({notifications}),
     notifications: []
 }))
+
+/**
+ * Gets a Zustand store for the current Chromium process
+ * @returns A Zustand store, and a function to send a command to the Node process
+ */
+export const getChromiumStore = () => {
+    if (typeof window === "undefined") {
+        throw new Error("Cannot get chromium store from node process")
+    }
+    return [getStore(), useVscode()] as const
+}
+
+/**
+ * Gets a Zustand store for the current Node process, creating it if necessary
+ * @returns A Zustand store, and a function to register a new connection to a webview
+ */
+export const getNodeStore = () => {
+    if (typeof window !== "undefined") {
+        throw new Error("Cannot get node store from chromium process")
+    }
+    return [getStore(), (connection: vscode.Webview) => getStore(connection)] as const
+}   

--- a/src/views/box.tsx
+++ b/src/views/box.tsx
@@ -1,11 +1,11 @@
 import React from "react"
 import { useStore } from "zustand"
-import { getStore } from "../state"
+import { getChromiumStore } from "../state"
 
 import styles from "./box.module.css"
 import globalStyles from "./global.module.css"
 
-const _store = getStore()
+const [_store, vscode] = getChromiumStore()
 
 export default function Box() {
   const store = useStore(_store)
@@ -26,6 +26,9 @@ export default function Box() {
             </li>
           ))}
         </ul>
+        <button onClick={() => {
+            vscode("window.showInformationMessage", ["It works!"])
+        }}>Test</button>
       </div>
     </div>
   )

--- a/src/views/box.tsx
+++ b/src/views/box.tsx
@@ -26,9 +26,6 @@ export default function Box() {
             </li>
           ))}
         </ul>
-        <button onClick={() => {
-            vscode("window.showInformationMessage", ["It works!"])
-        }}>Test</button>
       </div>
     </div>
   )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
         "jsx": "react",
+        "noEmit": true,
+        "allowImportingTsExtensions": true,
         /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
         /* Projects */


### PR DESCRIPTION
From within a webview component you can now go:

```
const [_store, vscode] = getChromiumStore()
```

and with the resulting `vscode` object you can execute arbitrary vscode commands on the main node process like:

```
onClick={() => {
    vscode("window.showInformationMessage", ["It works!"])
}}
```

normally this is not possible with each webview running in an iframe
